### PR TITLE
헤더바에 login user 이름 띄우기 / apollo local schema, state 학습

### DIFF
--- a/frontend/src/Apollo.ts
+++ b/frontend/src/Apollo.ts
@@ -1,34 +1,3 @@
-// import AWSAppSyncClient, { defaultDataIdFromObject } from 'aws-appsync';
-// import appSyncConfig from './aws-exports';
-
-// const client = new AWSAppSyncClient({
-//   url: appSyncConfig.aws_appsync_graphqlEndpoint,
-//   region: appSyncConfig.aws_appsync_region,
-//   auth: {
-//     type: 'AMAZON_COGNITO_USER_POOLS',
-//     apiKey: appSyncConfig.aws_appsync_apiKey,
-//   } as any,
-//   cacheOptions: {
-//     dataIdFromObject: (obj: any) => {
-//       const id = defaultDataIdFromObject(obj);
-
-//       if (!id) {
-//         const { __typename: typename } = obj;
-//         switch (typename) {
-//         case 'Comment':
-//           return `${typename}:${obj.commentId}`;
-//         default:
-//           return id;
-//         }
-//       }
-
-//       return id;
-//     },
-//   },
-// });
-
-// export default client;
-
 import { ApolloLink } from 'apollo-link';
 import { createAuthLink } from 'aws-appsync-auth-link';
 import { createHttpLink } from 'apollo-link-http';

--- a/frontend/src/Apollo.ts
+++ b/frontend/src/Apollo.ts
@@ -1,8 +1,7 @@
 import { ApolloLink } from 'apollo-link';
 import { createAuthLink } from 'aws-appsync-auth-link';
 import { createHttpLink } from 'apollo-link-http';
-import { ApolloClient } from '@apollo/client';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient, InMemoryCache, gql } from '@apollo/client';
 import appSyncConfig from 'aws-exports';
 
 const url = appSyncConfig.aws_appsync_graphqlEndpoint;
@@ -15,9 +14,26 @@ const link = ApolloLink.from([
   createAuthLink({ url, region, auth } as any) as any,
   createHttpLink({ uri: url }),
 ]);
+
+const typeDefs = gql`
+  extend type User {
+    username: String!
+  }
+
+  extend type Query {
+    getUser: User!
+  }
+
+  extend type Mutation {
+    setUser(username: String!): Boolean!
+  }
+
+`;
+
 const client = new ApolloClient({
   link,
   cache: new InMemoryCache(),
+  typeDefs,
 } as any);
 
 export default client;

--- a/frontend/src/components/UI/organisms/HeaderBar/index.tsx
+++ b/frontend/src/components/UI/organisms/HeaderBar/index.tsx
@@ -1,24 +1,28 @@
 import React from 'react';
 import LogoImg from 'images/LifemanagerMainLogo.png';
 import hambug from 'images/hambug.svg';
+import { loginUserName } from 'graphql/localState';
 import * as S from './style';
 
 export interface Props {
   className?: string;
 }
 
-const App = ({ className }: Props) => (
-  <>
-    <S.HeaderBar className={className}>
-      <S.Logo src={LogoImg} />
-      <S.DigitalClockWrap>
-        <S.DigitalClock />
-      </S.DigitalClockWrap>
-      <S.MenuBtn>
-        <S.HambugIcon src={hambug} />
-      </S.MenuBtn>
-    </S.HeaderBar>
-  </>
-);
+function App({ className }: Props) {
+  return (
+    <>
+      <S.HeaderBar className={className}>
+        <S.Logo src={LogoImg} />
+        <S.DigitalClockWrap>
+          <S.DigitalClock />
+        </S.DigitalClockWrap>
+        <div style={{ color: 'white' }}>{localStorage.getItem('loginUserName')}</div>
+        <S.MenuBtn>
+          <S.HambugIcon src={hambug} />
+        </S.MenuBtn>
+      </S.HeaderBar>
+    </>
+  );
+}
 
 export default App;

--- a/frontend/src/graphql/localMutations.ts
+++ b/frontend/src/graphql/localMutations.ts
@@ -1,0 +1,13 @@
+export const setUser = `
+  mutation SetUser(
+    $username: String!
+  ) {
+    setUser(
+      username: $username
+    ) @client {
+      true
+    }
+  }
+`;
+
+export default {};

--- a/frontend/src/graphql/localQueries.ts
+++ b/frontend/src/graphql/localQueries.ts
@@ -1,0 +1,7 @@
+export const getUser = /* GraphQL */ `
+  query GetUser {
+    getUser @client 
+  }
+`;
+
+export default {};

--- a/frontend/src/graphql/localState.ts
+++ b/frontend/src/graphql/localState.ts
@@ -1,0 +1,5 @@
+import { makeVar } from '@apollo/client';
+
+export const loginUserName = makeVar(localStorage.getItem('loginUserName') && 'nouser');
+
+export default {};

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -17,6 +17,7 @@ const loginOnClick = () => Auth.federatedSignIn();
 
 const App = ({ className }: any) => {
   const [loginState, setLoginState] = useState<any>({ user: null, customState: null });
+
   useEffect(() => {
     Hub.listen('auth', ({ payload: { event, data } }) => {
       switch (event) {
@@ -40,6 +41,9 @@ const App = ({ className }: any) => {
   }, []);
 
   const { user } = loginState;
+  if (user) {
+    localStorage.setItem('loginUserName', user.attributes.name);
+  }
 
   const contents = (
     <>

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -40,7 +40,6 @@ const App = ({ className }: any) => {
   }, []);
 
   const { user } = loginState;
-  console.log('user :: ', user);
 
   const contents = (
     <>

--- a/frontend/src/pages/TestComp/index.tsx
+++ b/frontend/src/pages/TestComp/index.tsx
@@ -7,7 +7,6 @@ const App = () => {
   const dispatch = useDispatch();
 
   dispatch(getOneUser(1));
-  console.log('render : ');
   return (
     <>
       <div>temp</div>


### PR DESCRIPTION
## 변경사항
헤더바에 username이 나온다 (localStorage 이용)

기존 apollo local state에 username을 저장해서 쓰려고 했다. 
local schema를 작성하고 mutation으로 로그인 시 username을 등록하고 query로 username을 가져와서 하려고 했는데 잘 안됐다.
Reactive variable을 통해 간단하게 해보려고 했는데 잘 안됐다.
문제는 OAuth로그인 시 redirect되면서 메모리가 다 날아가기 때문에 client 메모리에 저장되는 걸로는 구현할 수 없었다는 걸 알게 됐다.

## Linked Issue
closes #132