### PR TITLE
RecodeInput에서 카테고리 눌렀을 때 값 초기화 되는 것 수정 / RecodeList 정렬 로직 수정

### DIFF
--- a/frontend/src/components/UI/molecules/Recode/index.tsx
+++ b/frontend/src/components/UI/molecules/Recode/index.tsx
@@ -18,6 +18,18 @@ export interface Props extends IRecode {
   className?: string;
 }
 
+const getNowTime = (startTime: IHmTime, endTime: IHmTime) => {
+  const calTime = calNowTime(startTime, endTime);
+  if (calTime.hour === 99) {
+    const nowTime = {
+      hour: new Date().getHours(),
+      min: new Date().getMinutes(),
+    };
+    return calNowTime(startTime, nowTime);
+  }
+  return calTime;
+};
+
 function Recode({
   title,
   startTime,
@@ -27,7 +39,8 @@ function Recode({
   onClick,
   className,
 }: Props) {
-  const nowTime = calNowTime(startTime, endTime);
+  const nowTime = getNowTime(startTime, endTime);
+
   return (
     <S.Recode onClick={onClick} className={className} >
       <S.UpperWrap>

--- a/frontend/src/components/UI/organisms/Board/index.tsx
+++ b/frontend/src/components/UI/organisms/Board/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IRecode } from 'components/UI/molecules/Recode';
-import { calNowTime } from 'libs/time';
+import { nowHourMin, calNowTime } from 'libs/time';
 import * as S from './style';
 
 export interface Props {
@@ -11,7 +11,7 @@ export interface Props {
 
 function Board({ goalTime, recodeList, className }: Props) {
   const nowTime = recodeList?.reduce((acc: number, recode: IRecode) => {
-    const endTime = recode.endTime ? recode.endTime : { hour: 0, min: 0 };
+    const endTime = recode.endTime?.hour ? recode.endTime : nowHourMin();
     const calValue = calNowTime(recode.startTime, endTime);
     return acc + calValue.hour + calValue.min / 60;
   }, 0).toFixed(1);

--- a/frontend/src/components/UI/organisms/RecodeList/index.tsx
+++ b/frontend/src/components/UI/organisms/RecodeList/index.tsx
@@ -26,10 +26,18 @@ interface Props {
   className?: string;
 }
 
+const getBiasHour = (recode: ITimeRecode, bias: number = 4) => {
+  const biasHour = recode.startTime.hour - bias;
+  if (biasHour < 0) {
+    return biasHour + 24;
+  }
+  return biasHour;
+};
+
 const sortByStartTime = (recode1:ITimeRecode, recode2: ITimeRecode) => {
-  const startTimeDiff = recode1.startTime.hour - recode2.startTime.hour;
+  const startTimeDiff = getBiasHour(recode1) - getBiasHour(recode2);
   if (startTimeDiff === 0) {
-    return recode1.startTime.min - recode2.startTime.min;
+    return (recode1.startTime.min - recode2.startTime.min);
   }
   return startTimeDiff;
 };
@@ -61,7 +69,7 @@ function RecodeList({
         + recode.endTime.min}
       title={recode.title}
       startTime={recode.startTime}
-      endTime={recode.endTime}
+      endTime={recode.endTime.hour ? recode.endTime : undefined}
       category={recode.category}
       onClick={recodeOnClick(recode.id)}
       isActive={recode.isActive} />

--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -37,7 +37,6 @@ function Main() {
   if (!userLoading && !userError) {
     if (userData) {
       if (userData.getUser.items.length !== 0) {
-        console.log(userData.getUser.items[0]);
         tempLabelList = userData.getUser.items[0]?.categoryList;
         tempGoalTime = userData.getUser.items[0]?.goalTime;
       } else {


### PR DESCRIPTION
## 변경사항
* RecodeInput에서 카테고리 눌렀을 때 값이 초기화 됐다.
* categorySelect의 state가 바뀌면서 RecodeInput이 rerendering되는데 이 때 fetch해서 가져온 데이터를 input ref에 덮어쓰는 로직이 계속 실행되었다. 
* fetch완료된 경우 상태 관리를 위해 ref로 상태관리해서 해결
* RecodeList 정렬 로직 수정 [wiki](https://github.com/pkiop/lifemanager/wiki/0%EC%97%90%EC%84%9C-23-%EC%88%9C%EC%9C%BC%EB%A1%9C-%EC%98%A4%EB%A6%84%EC%B0%A8%EC%88%9C%EC%9D%84-4~...24...~3%EC%9C%BC%EB%A1%9C-%EB%B3%80%EA%B2%BD%ED%95%98%EB%8A%94-%EB%A1%9C%EC%A7%81)

## Linked Issue
